### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "description": "Memory game with Octocats",
   "version": "0.0.1",
   "dependencies": {
-    "debug": "2.6.8",
+    "debug": ">=2.6.9",
     "ejs": "^2.5.6",
     "hoek": "^4.0.0",
     "npm": "^6.4.1",
     "streaming-json-stringify": "^3.1.0"
   },
   "devDependencies": {
-    "eslint": "^6.2.2"
+    "eslint": ">=2.6.9"
   },
   "engines": {
     "npm": "2.15.0"


### PR DESCRIPTION
Remediation
Upgrade debug to version 2.6.9 or later. For example:

"dependencies": {
  "debug": ">=2.6.9"
}
or…
"devDependencies": {
  "debug": ">=2.6.9"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2017-16137
low severity
Vulnerable versions: < 2.6.9
Patched version: 2.6.9
Affected versions of debug are vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter.

As it takes 50,000 characters to block the event loop for 2 seconds, this issue is a low severity issue.

Recommendation
Version 2.x.x: Update to version 2.6.9 or later.
Version 3.x.x: Update to version 3.1.0 or later.